### PR TITLE
Fix security vulnerability in minimatch dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -853,9 +853,9 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+            "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {


### PR DESCRIPTION
- Update minimatch from 5.1.6 to 5.1.9
- Resolves CVE-2026-27903 (high severity ReDoS vulnerabilities)
- Fixes multiple regular expression denial of service issues